### PR TITLE
Fix unwanted grey margin in cards on the news page

### DIFF
--- a/app/src/components/NewsList.vue
+++ b/app/src/components/NewsList.vue
@@ -15,18 +15,12 @@
           <div v-for="(item, index) in items" :key="index">
             <b-card class="news-item" :img-src="item.urlToImage" :title="item.title">
               <b-card-text>{{ item.description }}</b-card-text>
-              <template v-slot:footer style="padding: 1.5rem 1.25rem">
-                <span class="float-left">
-                  <a :href="item.url"><i>{{$t("message.newsList_source")}}</i></a>
-                </span>
-                <div class="float-right">
-                  <small class="text-muted">
-                    {{
-                    moment(item.publishedAt)
-                    }}
-                  </small>
-                </div>
-              </template>
+              <div class="news-metadata">
+                <a :href="item.url"><i>{{$t("message.newsList_source")}}</i></a>
+                <small class="text-muted">
+                  {{ moment(item.publishedAt) }}
+                </small>
+              </div>
             </b-card>
           </div>
         </b-card-group>
@@ -64,6 +58,11 @@ export default {
   font-size: 3em;
 }
 
+.news-metadata {
+  display: flex;
+  justify-content: space-between;
+}
+
 .news__con {
   padding: 1em 1em;
 }
@@ -77,7 +76,6 @@ export default {
 }
 
 .news-item {
-  /* width: 100%; */
   margin-bottom: 4em;
 }
 


### PR DESCRIPTION
# Overview
This PR fixes the unwanted grey margin in cards on the news page!

# Changes
* Edited vue template for the b-card rendering in `NewList.vue`

# Mock/Screenshot
![Screenshot from 2020-05-02 19-26-28](https://user-images.githubusercontent.com/16375966/80897163-dc811f00-8caa-11ea-9789-0595d35205b4.png)


# Testing
Tested on local dev server, mobile and web layouts

# Issue
#6 
